### PR TITLE
:construction_worker: fix: Move PR template to the .github/ root

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ## Your checklist for this pull request
 
-🚨 Please review the [guidelines for contributing](Documents/Candy-Doc/candy-doc-maven-plugin/CONTRIBUTING.md) to
+🚨 Please review the [guidelines for contributing](../../CONTRIBUTING.md) to
 this repository.
 
 - [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ## Your checklist for this pull request
 
-🚨 Please review the [guidelines for contributing](../../CONTRIBUTING.md) to
+🚨 Please review the [guidelines for contributing](Documents/Candy-Doc/candy-doc-maven-plugin/CONTRIBUTING.md) to
 this repository.
 
 - [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right


### PR DESCRIPTION
# Pull request for Candy-doc

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](Documents/Candy-Doc/candy-doc-maven-plugin/CONTRIBUTING.md) to
this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right
  side). Don't request your master!
- [x] Make sure you are making a pull request against the **main branch** (left
  side).
- [x] Check the commit's or even all commits' message styles matches our
  requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit
  test.

## Description

Just move the template to be able to auto-setup it in GitHub

❤️ Thank you!
