### PR TITLE
:recycle: feat: Split extract_ddd_concepts tests into multiple files

### DIFF
--- a/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractBoundedContextUseCaseTest.java
+++ b/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractBoundedContextUseCaseTest.java
@@ -1,6 +1,7 @@
 package io.candydoc.ddd.extract_ddd_concepts;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.candydoc.ddd.Command;
@@ -12,25 +13,19 @@ import io.candydoc.ddd.domain_command.DomainCommandFound;
 import io.candydoc.ddd.domain_event.DomainEventFound;
 import io.candydoc.ddd.interaction.ConceptRuleViolated;
 import io.candydoc.ddd.interaction.InteractionBetweenConceptFound;
-import io.candydoc.ddd.model.ExtractionException;
-import io.candydoc.ddd.shared_kernel.SharedKernelFound;
 import io.candydoc.ddd.value_object.ValueObjectFound;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-class ExtractDDDConceptsUseCaseTest {
-
+class ExtractBoundedContextUseCaseTest {
   private ExtractDDDConceptsUseCase extractDDDConceptsUseCase;
   private SaveDocumentationPort saveDocumentationPort;
   private DDDConceptsExtractionService dddConceptsExtractionService;
@@ -46,64 +41,6 @@ class ExtractDDDConceptsUseCaseTest {
         new ExtractDDDConceptsUseCase(dddConceptsExtractionService, saveDocumentationPort);
 
     doAnswer(extractionCaptor).when(dddConceptsExtractionService).extract(any(Command.class));
-  }
-
-  @Test
-  void package_to_scan_is_not_provided() {
-    // given
-    ExtractDDDConcepts command = ExtractDDDConcepts.builder().packagesToScan(List.of()).build();
-
-    // when then
-    Assertions.assertThatThrownBy(() -> extractDDDConceptsUseCase.execute(command))
-        .isInstanceOf(PackageToScanMissing.class)
-        .hasMessage("Missing parameters for 'packageToScan'. Check your pom configuration.");
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"", "    ", "  \t  "})
-  void blank_package_to_scan_is_not_allowed(String packageToScan) {
-    // given
-    ExtractDDDConcepts command = ExtractDDDConcepts.builder().packageToScan(packageToScan).build();
-
-    // when then
-    Assertions.assertThatThrownBy(() -> extractDDDConceptsUseCase.execute(command))
-        .isInstanceOf(PackageToScanMissing.class)
-        .hasMessage(
-            "Blank packageToScan not allowed for 'packagesToScan'. Check your pom configuration");
-  }
-
-  @Test
-  void generated_documentation_from_multiple_packages() throws ExtractionException, IOException {
-    // given
-    ArgumentCaptor<List<Event>> resultCaptor = ArgumentCaptor.forClass(List.class);
-
-    // when
-    extractDDDConceptsUseCase.execute(
-        ExtractDDDConcepts.builder()
-            .packageToScan("io.candydoc.sample.valid_bounded_contexts.bounded_context_one")
-            .packageToScan("io.candydoc.sample.second_valid_bounded_contexts")
-            .build());
-
-    // then
-    verify(saveDocumentationPort, times(1)).save(resultCaptor.capture());
-
-    List<Event> occurredGenerationEvents = resultCaptor.getValue();
-
-    assertThat(occurredGenerationEvents).isNotEmpty();
-  }
-
-  @Test
-  void no_bounded_context_nor_shared_kernel_in_the_package_to_scan() {
-    // given
-    ExtractDDDConcepts command =
-        ExtractDDDConcepts.builder().packageToScan("wrong.package.to.scan").build();
-
-    // then
-    Assertions.assertThatThrownBy(() -> extractDDDConceptsUseCase.execute(command))
-        .isInstanceOf(NoBoundedContextNorSharedKernelFound.class)
-        .hasMessage(
-            "No bounded context nor shared kernel has been found in this packages :"
-                + " '[wrong.package.to.scan]'.");
   }
 
   @Test
@@ -198,28 +135,6 @@ class ExtractDDDConceptsUseCaseTest {
   }
 
   @Test
-  void value_object_should_only_contain_primitive_types() throws IOException {
-    // given
-    ExtractDDDConcepts command =
-        ExtractDDDConcepts.builder()
-            .packageToScan("io.candydoc.sample.bounded_context_for_wrong_usage_of_value_objects")
-            .build();
-
-    // when
-    extractDDDConceptsUseCase.execute(command);
-
-    // then
-    assertThat(extractionCaptor.getResult())
-        .filteredOn(ConceptRuleViolated.class::isInstance)
-        .containsExactlyInAnyOrder(
-            ConceptRuleViolated.builder()
-                .conceptName(
-                    "io.candydoc.sample.bounded_context_for_wrong_usage_of_value_objects.sub_package.ValueObject")
-                .reason("Value Object should only contain primitive types")
-                .build());
-  }
-
-  @Test
   void find_domain_events_inside_bounded_contexts() throws IOException {
     // given
     ExtractDDDConcepts command =
@@ -297,128 +212,6 @@ class ExtractDDDConceptsUseCaseTest {
                 .build());
   }
 
-  @Test
-  void find_interaction_between_two_different_concepts() throws IOException {
-    // given
-    ExtractDDDConcepts command =
-        ExtractDDDConcepts.builder()
-            .packageToScan("io.candydoc.sample.valid_bounded_contexts")
-            .build();
-
-    // when
-    extractDDDConceptsUseCase.execute(command);
-
-    // then
-    assertThat(extractionCaptor.getResult())
-        .filteredOn(InteractionBetweenConceptFound.class::isInstance)
-        .containsExactlyInAnyOrder(
-            InteractionBetweenConceptFound.builder()
-                .from(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept1")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.ValueObject1")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept1")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept2")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.DomainEvent1")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept1")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.Aggregate1")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept2")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.DomainCommand1")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.ValueObject1")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_two.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_two.sub_package.CoreConcept1")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.shared_kernel.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.ValueObject1")
-                .build(),
-            InteractionBetweenConceptFound.builder()
-                .from("io.candydoc.sample.valid_bounded_contexts.shared_kernel.package-info")
-                .with(
-                    "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.CoreConcept1")
-                .build());
-  }
-
-  @Test
-  void find_shared_kernel_inside_given_packages() throws IOException {
-    // given
-    ExtractDDDConcepts command =
-        ExtractDDDConcepts.builder()
-            .packageToScan("io.candydoc.sample.valid_bounded_contexts")
-            .build();
-
-    // when
-    extractDDDConceptsUseCase.execute(command);
-
-    // then
-    assertThat(extractionCaptor.getResult())
-        .contains(
-            SharedKernelFound.builder()
-                .simpleName("shared_kernel_one")
-                .canonicalName(
-                    "io.candydoc.sample.valid_bounded_contexts.shared_kernel.package-info")
-                .description("description of shared kernel")
-                .packageName("io.candydoc.sample.valid_bounded_contexts.shared_kernel")
-                .build());
-  }
-
-  @Test
-  void find_core_concepts_inside_shared_kernel() throws IOException {
-    // given
-    ExtractDDDConcepts command =
-        ExtractDDDConcepts.builder()
-            .packageToScan("io.candydoc.sample.valid_bounded_contexts.shared_kernel")
-            .build();
-
-    // when
-    extractDDDConceptsUseCase.execute(command);
-
-    // then
-    assertThat(extractionCaptor.getResult())
-        .filteredOn(CoreConceptFound.class::isInstance)
-        .containsExactlyInAnyOrder(
-            CoreConceptFound.builder()
-                .simpleName("name of core concept 1 of shared kernel 1")
-                .description("description of core concept 1 of shared kernel 1")
-                .canonicalName(
-                    "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.CoreConcept1")
-                .packageName("io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package")
-                .boundedContext("io.candydoc.sample.valid_bounded_contexts.shared_kernel")
-                .build());
-  }
-
   @ParameterizedTest
   @MethodSource("forbidden_concepts_in_bounded_context_examples")
   void forbidden_concepts_in_bounded_context(String conceptName, String ruleViolatedReason)
@@ -461,47 +254,6 @@ class ExtractDDDConceptsUseCaseTest {
   }
 
   @ParameterizedTest
-  @MethodSource("forbidden_concepts_in_shared_kernel_examples")
-  void forbidden_concepts_in_shared_kernel(String conceptName, String ruleViolatedReason)
-      throws IOException {
-    // given
-    ExtractDDDConcepts command =
-        ExtractDDDConcepts.builder()
-            .packageToScan("io.candydoc.sample.wrong_bounded_contexts")
-            .build();
-
-    // when
-    extractDDDConceptsUseCase.execute(command);
-
-    // then
-    assertThat(extractionCaptor.getResult())
-        .contains(
-            ConceptRuleViolated.builder()
-                .conceptName(conceptName)
-                .reason(ruleViolatedReason)
-                .build());
-  }
-
-  public static Stream<Arguments> forbidden_concepts_in_shared_kernel_examples() {
-    return Stream.of(
-        Arguments.of(
-            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.sub_package.Aggregate1",
-            "Shared kernel can not have aggregate."),
-        Arguments.of(
-            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.sub_package.DomainCommand1",
-            "Shared kernel can not have domain command."),
-        Arguments.of(
-            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.sub_package.DomainEvent1",
-            "Shared kernel can not have domain event."),
-        Arguments.of(
-            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.inner_bounded_context",
-            "Bounded context bounded_context_three is not allowed in a shared kernel."),
-        Arguments.of(
-            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.inner_shared_kernel",
-            "Shared kernel shared_kernel_two is not allowed in another shared kernel."));
-  }
-
-  @ParameterizedTest
   @MethodSource("allowed_interactions_with_bounded_context_examples")
   void find_interactions_with_bounded_context(String conceptName) throws IOException {
     // given
@@ -536,35 +288,6 @@ class ExtractDDDConceptsUseCaseTest {
             "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.DomainEvent1"),
         Arguments.of(
             "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.ValueObject1"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("allowed_interactions_with_shared_kernel_examples")
-  void find_interactions_with_shared_kernel(String conceptName) throws IOException {
-    // given
-    ExtractDDDConcepts command =
-        ExtractDDDConcepts.builder()
-            .packageToScan("io.candydoc.sample.valid_bounded_contexts")
-            .build();
-
-    // when
-    extractDDDConceptsUseCase.execute(command);
-
-    // then
-    assertThat(extractionCaptor.getResult())
-        .contains(
-            InteractionBetweenConceptFound.builder()
-                .with(conceptName)
-                .from("io.candydoc.sample.valid_bounded_contexts.shared_kernel.package-info")
-                .build());
-  }
-
-  public static Stream<Arguments> allowed_interactions_with_shared_kernel_examples() {
-    return Stream.of(
-        Arguments.of(
-            "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.CoreConcept1"),
-        Arguments.of(
-            "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.ValueObject1"));
   }
 
   public class ResultCaptor<T> implements Answer {

--- a/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractDomainContextUseCaseTest.java
+++ b/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractDomainContextUseCaseTest.java
@@ -1,0 +1,60 @@
+package io.candydoc.ddd.extract_ddd_concepts;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.candydoc.ddd.Command;
+import io.candydoc.ddd.Event;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+class ExtractDomainContextUseCaseTest {
+  private ExtractDDDConceptsUseCase extractDDDConceptsUseCase;
+  private SaveDocumentationPort saveDocumentationPort;
+  private DDDConceptsExtractionService dddConceptsExtractionService;
+
+  private ResultCaptor<List<Event>> extractionCaptor = new ResultCaptor<>();
+
+  @BeforeEach
+  public void setUp() {
+    saveDocumentationPort = mock(SaveDocumentationPort.class);
+    dddConceptsExtractionService =
+        spy(new DDDConceptsExtractionService(new ReflectionsConceptFinder(List.of("io.candydoc"))));
+    extractDDDConceptsUseCase =
+        new ExtractDDDConceptsUseCase(dddConceptsExtractionService, saveDocumentationPort);
+
+    doAnswer(extractionCaptor).when(dddConceptsExtractionService).extract(any(Command.class));
+  }
+
+  @Test
+  void no_bounded_context_nor_shared_kernel_in_the_package_to_scan() {
+    // given
+    ExtractDDDConcepts command =
+        ExtractDDDConcepts.builder().packageToScan("wrong.package.to.scan").build();
+
+    // then
+    Assertions.assertThatThrownBy(() -> extractDDDConceptsUseCase.execute(command))
+        .isInstanceOf(NoBoundedContextNorSharedKernelFound.class)
+        .hasMessage(
+            "No bounded context nor shared kernel has been found in this packages :"
+                + " '[wrong.package.to.scan]'.");
+  }
+
+  public class ResultCaptor<T> implements Answer {
+    private T result = null;
+
+    public T getResult() {
+      return result;
+    }
+
+    @Override
+    public T answer(InvocationOnMock invocationOnMock) throws Throwable {
+      result = (T) invocationOnMock.callRealMethod();
+      return result;
+    }
+  }
+}

--- a/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractGeneralUseCaseTest.java
+++ b/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractGeneralUseCaseTest.java
@@ -1,0 +1,171 @@
+package io.candydoc.ddd.extract_ddd_concepts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.candydoc.ddd.Command;
+import io.candydoc.ddd.Event;
+import io.candydoc.ddd.interaction.InteractionBetweenConceptFound;
+import io.candydoc.ddd.model.ExtractionException;
+import java.io.IOException;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+class ExtractGeneralUseCaseTest {
+
+  private ExtractDDDConceptsUseCase extractDDDConceptsUseCase;
+  private SaveDocumentationPort saveDocumentationPort;
+  private DDDConceptsExtractionService dddConceptsExtractionService;
+
+  private ResultCaptor<List<Event>> extractionCaptor = new ResultCaptor<>();
+
+  @BeforeEach
+  public void setUp() {
+    saveDocumentationPort = mock(SaveDocumentationPort.class);
+    dddConceptsExtractionService =
+        spy(new DDDConceptsExtractionService(new ReflectionsConceptFinder(List.of("io.candydoc"))));
+    extractDDDConceptsUseCase =
+        new ExtractDDDConceptsUseCase(dddConceptsExtractionService, saveDocumentationPort);
+
+    doAnswer(extractionCaptor).when(dddConceptsExtractionService).extract(any(Command.class));
+  }
+
+  @Test
+  void package_to_scan_is_not_provided() {
+    // given
+    ExtractDDDConcepts command = ExtractDDDConcepts.builder().packagesToScan(List.of()).build();
+
+    // when then
+    Assertions.assertThatThrownBy(() -> extractDDDConceptsUseCase.execute(command))
+        .isInstanceOf(PackageToScanMissing.class)
+        .hasMessage("Missing parameters for 'packageToScan'. Check your pom configuration.");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "    ", "  \t  "})
+  void blank_package_to_scan_is_not_allowed(String packageToScan) {
+    // given
+    ExtractDDDConcepts command = ExtractDDDConcepts.builder().packageToScan(packageToScan).build();
+
+    // when then
+    Assertions.assertThatThrownBy(() -> extractDDDConceptsUseCase.execute(command))
+        .isInstanceOf(PackageToScanMissing.class)
+        .hasMessage(
+            "Blank packageToScan not allowed for 'packagesToScan'. Check your pom configuration");
+  }
+
+  @Test
+  void generated_documentation_from_multiple_packages() throws ExtractionException, IOException {
+    // given
+    ArgumentCaptor<List<Event>> resultCaptor = ArgumentCaptor.forClass(List.class);
+
+    // when
+    extractDDDConceptsUseCase.execute(
+        ExtractDDDConcepts.builder()
+            .packageToScan("io.candydoc.sample.valid_bounded_contexts.bounded_context_one")
+            .packageToScan("io.candydoc.sample.second_valid_bounded_contexts")
+            .build());
+
+    // then
+    verify(saveDocumentationPort, times(1)).save(resultCaptor.capture());
+
+    List<Event> occurredGenerationEvents = resultCaptor.getValue();
+
+    assertThat(occurredGenerationEvents).isNotEmpty();
+  }
+
+  @Test
+  void find_interaction_between_two_different_concepts() throws IOException {
+    // given
+    ExtractDDDConcepts command =
+        ExtractDDDConcepts.builder()
+            .packageToScan("io.candydoc.sample.valid_bounded_contexts")
+            .build();
+
+    // when
+    extractDDDConceptsUseCase.execute(command);
+
+    // then
+    assertThat(extractionCaptor.getResult())
+        .filteredOn(InteractionBetweenConceptFound.class::isInstance)
+        .containsExactlyInAnyOrder(
+            InteractionBetweenConceptFound.builder()
+                .from(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept1")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.ValueObject1")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept1")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept2")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.DomainEvent1")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept1")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.Aggregate1")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.CoreConcept2")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.DomainCommand1")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_one.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_one.sub_package.ValueObject1")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.bounded_context_two.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.bounded_context_two.sub_package.CoreConcept1")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.shared_kernel.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.ValueObject1")
+                .build(),
+            InteractionBetweenConceptFound.builder()
+                .from("io.candydoc.sample.valid_bounded_contexts.shared_kernel.package-info")
+                .with(
+                    "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.CoreConcept1")
+                .build());
+  }
+
+  public class ResultCaptor<T> implements Answer {
+    private T result = null;
+
+    public T getResult() {
+      return result;
+    }
+
+    @Override
+    public T answer(InvocationOnMock invocationOnMock) throws Throwable {
+      result = (T) invocationOnMock.callRealMethod();
+      return result;
+    }
+  }
+}

--- a/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractSharedKernelUseCaseTest.java
+++ b/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractSharedKernelUseCaseTest.java
@@ -1,0 +1,173 @@
+package io.candydoc.ddd.extract_ddd_concepts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.candydoc.ddd.Command;
+import io.candydoc.ddd.Event;
+import io.candydoc.ddd.core_concept.CoreConceptFound;
+import io.candydoc.ddd.interaction.ConceptRuleViolated;
+import io.candydoc.ddd.interaction.InteractionBetweenConceptFound;
+import io.candydoc.ddd.shared_kernel.SharedKernelFound;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+class ExtractSharedKernelUseCaseTest {
+  private ExtractDDDConceptsUseCase extractDDDConceptsUseCase;
+  private SaveDocumentationPort saveDocumentationPort;
+  private DDDConceptsExtractionService dddConceptsExtractionService;
+
+  private ResultCaptor<List<Event>> extractionCaptor = new ResultCaptor<>();
+
+  @BeforeEach
+  public void setUp() {
+    saveDocumentationPort = mock(SaveDocumentationPort.class);
+    dddConceptsExtractionService =
+        spy(new DDDConceptsExtractionService(new ReflectionsConceptFinder(List.of("io.candydoc"))));
+    extractDDDConceptsUseCase =
+        new ExtractDDDConceptsUseCase(dddConceptsExtractionService, saveDocumentationPort);
+
+    doAnswer(extractionCaptor).when(dddConceptsExtractionService).extract(any(Command.class));
+  }
+
+  @Test
+  void find_shared_kernel_inside_given_packages() throws IOException {
+    // given
+    ExtractDDDConcepts command =
+        ExtractDDDConcepts.builder()
+            .packageToScan("io.candydoc.sample.valid_bounded_contexts")
+            .build();
+
+    // when
+    extractDDDConceptsUseCase.execute(command);
+
+    // then
+    assertThat(extractionCaptor.getResult())
+        .contains(
+            SharedKernelFound.builder()
+                .simpleName("shared_kernel_one")
+                .canonicalName(
+                    "io.candydoc.sample.valid_bounded_contexts.shared_kernel.package-info")
+                .description("description of shared kernel")
+                .packageName("io.candydoc.sample.valid_bounded_contexts.shared_kernel")
+                .build());
+  }
+
+  @Test
+  void find_core_concepts_inside_shared_kernel() throws IOException {
+    // given
+    ExtractDDDConcepts command =
+        ExtractDDDConcepts.builder()
+            .packageToScan("io.candydoc.sample.valid_bounded_contexts.shared_kernel")
+            .build();
+
+    // when
+    extractDDDConceptsUseCase.execute(command);
+
+    // then
+    assertThat(extractionCaptor.getResult())
+        .filteredOn(CoreConceptFound.class::isInstance)
+        .containsExactlyInAnyOrder(
+            CoreConceptFound.builder()
+                .simpleName("name of core concept 1 of shared kernel 1")
+                .description("description of core concept 1 of shared kernel 1")
+                .canonicalName(
+                    "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.CoreConcept1")
+                .packageName("io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package")
+                .boundedContext("io.candydoc.sample.valid_bounded_contexts.shared_kernel")
+                .build());
+  }
+
+  @ParameterizedTest
+  @MethodSource("forbidden_concepts_in_shared_kernel_examples")
+  void forbidden_concepts_in_shared_kernel(String conceptName, String ruleViolatedReason)
+      throws IOException {
+    // given
+    ExtractDDDConcepts command =
+        ExtractDDDConcepts.builder()
+            .packageToScan("io.candydoc.sample.wrong_bounded_contexts")
+            .build();
+
+    // when
+    extractDDDConceptsUseCase.execute(command);
+
+    // then
+    assertThat(extractionCaptor.getResult())
+        .contains(
+            ConceptRuleViolated.builder()
+                .conceptName(conceptName)
+                .reason(ruleViolatedReason)
+                .build());
+  }
+
+  public static Stream<Arguments> forbidden_concepts_in_shared_kernel_examples() {
+    return Stream.of(
+        Arguments.of(
+            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.sub_package.Aggregate1",
+            "Shared kernel can not have aggregate."),
+        Arguments.of(
+            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.sub_package.DomainCommand1",
+            "Shared kernel can not have domain command."),
+        Arguments.of(
+            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.sub_package.DomainEvent1",
+            "Shared kernel can not have domain event."),
+        Arguments.of(
+            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.inner_bounded_context",
+            "Bounded context bounded_context_three is not allowed in a shared kernel."),
+        Arguments.of(
+            "io.candydoc.sample.wrong_bounded_contexts.shared_kernel.inner_shared_kernel",
+            "Shared kernel shared_kernel_two is not allowed in another shared kernel."));
+  }
+
+  @ParameterizedTest
+  @MethodSource("allowed_interactions_with_shared_kernel_examples")
+  void find_interactions_with_shared_kernel(String conceptName) throws IOException {
+    // given
+    ExtractDDDConcepts command =
+        ExtractDDDConcepts.builder()
+            .packageToScan("io.candydoc.sample.valid_bounded_contexts")
+            .build();
+
+    // when
+    extractDDDConceptsUseCase.execute(command);
+
+    // then
+    assertThat(extractionCaptor.getResult())
+        .contains(
+            InteractionBetweenConceptFound.builder()
+                .with(conceptName)
+                .from("io.candydoc.sample.valid_bounded_contexts.shared_kernel.package-info")
+                .build());
+  }
+
+  public static Stream<Arguments> allowed_interactions_with_shared_kernel_examples() {
+    return Stream.of(
+        Arguments.of(
+            "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.CoreConcept1"),
+        Arguments.of(
+            "io.candydoc.sample.valid_bounded_contexts.shared_kernel.sub_package.ValueObject1"));
+  }
+
+  public class ResultCaptor<T> implements Answer {
+    private T result = null;
+
+    public T getResult() {
+      return result;
+    }
+
+    @Override
+    public T answer(InvocationOnMock invocationOnMock) throws Throwable {
+      result = (T) invocationOnMock.callRealMethod();
+      return result;
+    }
+  }
+}

--- a/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractValueObjectUseCaseTest.java
+++ b/src/test/java/io/candydoc/ddd/extract_ddd_concepts/ExtractValueObjectUseCaseTest.java
@@ -1,0 +1,70 @@
+package io.candydoc.ddd.extract_ddd_concepts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.candydoc.ddd.Command;
+import io.candydoc.ddd.Event;
+import io.candydoc.ddd.interaction.ConceptRuleViolated;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+class ExtractValueObjectUseCaseTest {
+  private ExtractDDDConceptsUseCase extractDDDConceptsUseCase;
+  private SaveDocumentationPort saveDocumentationPort;
+  private DDDConceptsExtractionService dddConceptsExtractionService;
+
+  private ResultCaptor<List<Event>> extractionCaptor = new ResultCaptor<>();
+
+  @BeforeEach
+  public void setUp() {
+    saveDocumentationPort = mock(SaveDocumentationPort.class);
+    dddConceptsExtractionService =
+        spy(new DDDConceptsExtractionService(new ReflectionsConceptFinder(List.of("io.candydoc"))));
+    extractDDDConceptsUseCase =
+        new ExtractDDDConceptsUseCase(dddConceptsExtractionService, saveDocumentationPort);
+
+    doAnswer(extractionCaptor).when(dddConceptsExtractionService).extract(any(Command.class));
+  }
+
+  @Test
+  void value_object_should_only_contain_primitive_types() throws IOException {
+    // given
+    ExtractDDDConcepts command =
+        ExtractDDDConcepts.builder()
+            .packageToScan("io.candydoc.sample.bounded_context_for_wrong_usage_of_value_objects")
+            .build();
+
+    // when
+    extractDDDConceptsUseCase.execute(command);
+
+    // then
+    assertThat(extractionCaptor.getResult())
+        .filteredOn(ConceptRuleViolated.class::isInstance)
+        .containsExactlyInAnyOrder(
+            ConceptRuleViolated.builder()
+                .conceptName(
+                    "io.candydoc.sample.bounded_context_for_wrong_usage_of_value_objects.sub_package.ValueObject")
+                .reason("Value Object should only contain primitive types")
+                .build());
+  }
+
+  public class ResultCaptor<T> implements Answer {
+    private T result = null;
+
+    public T getResult() {
+      return result;
+    }
+
+    @Override
+    public T answer(InvocationOnMock invocationOnMock) throws Throwable {
+      result = (T) invocationOnMock.callRealMethod();
+      return result;
+    }
+  }
+}


### PR DESCRIPTION
# Pull request for Candy-doc

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../../CONTRIBUTING.md) to
this repository.

- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right
  side). Don't request your master!
- [X] Make sure you are making a pull request against the **main branch** (left
  side).
- [X] Check the commit's or even all commits' message styles matches our
  requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit
  test.

## Description

I wanted to separate tests done in ExtractDDDConceptsUseCaseTest to make a file by concept if it's possible.
This way when we want to add a test to a type of DDD concept we don't have to search between all methods in a big test file.

❤️ Thank you!
